### PR TITLE
Use the original property for debug and loglevel

### DIFF
--- a/lib/LoggerBuilder.ts
+++ b/lib/LoggerBuilder.ts
@@ -1,11 +1,12 @@
-/// <reference types="@nextcloud/typings" />
-
 import { getCurrentUser } from '@nextcloud/auth'
 import { IContext, ILogger, ILoggerFactory, LogLevel } from './contracts'
 
 declare global {
     interface Window {
-        OC: Nextcloud.v23.OC | Nextcloud.v24.OC | Nextcloud.v25.OC;
+        _oc_config: {
+            loglevel: LogLevel,
+        },
+        _oc_debug: boolean,
     }
 }
 
@@ -76,11 +77,11 @@ export class LoggerBuilder {
 
 		// Use arrow function to prevent undefined `this` within event handler
 		const onLoaded = () => {
-			if (document.readyState === 'complete' || (document.readyState === 'interactive' && window.OC !== undefined)) {
+			if (document.readyState === 'complete' || (document.readyState === 'interactive')) {
 				// Up to, including, nextcloud 24 the loglevel was not exposed
-				self.context.level = window.OC?.config?.loglevel !== undefined ? window.OC.config.loglevel : LogLevel.Warn
+				self.context.level = window._oc_config?.loglevel ?? LogLevel.Warn
 				// Override loglevel if we are in debug mode
-				if (window.OC?.debug) {
+				if (window._oc_debug) {
 					self.context.level = LogLevel.Debug
 				}
 				document.removeEventListener('readystatechange', onLoaded)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/logger",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/LoggerBuilder.spec.ts
+++ b/tests/LoggerBuilder.spec.ts
@@ -11,21 +11,21 @@ describe('detect logging level', () => {
         if (state === 'complete') global.window.dispatchEvent(new Event('load'))
         global.window.document.dispatchEvent(new Event('readystatechange'))
     }
-    
+
     beforeAll(() => {
         state = global.window.document.readyState
-        
+
         Object.defineProperty(global.window.document, "readyState", {
             get() { return state }
         })
     })
 
-    describe('without `OC.config.loglevel` (<=NC24)', () => {
+    describe('without `_oc_config.loglevel` (<=NC24)', () => {
         afterEach(() => {
             // @ts-expect-error
-            delete window.OC
+            delete window._oc_config
         })
-        it ('without `OC.debug`', async () => {
+        it ('without `_oc_debug`', async () => {
             setReadyState('loading')
             const builder = getLoggerBuilder()
             builder.detectLogLevel()
@@ -40,11 +40,11 @@ describe('detect logging level', () => {
             // Level should now be set
             expect('level' in builder.getContext()).toBe(true)
 
-            // Should default to warn as NC24 has no `OC.config.loglevel`
+            // Should default to warn as NC24 has no `_oc_config.loglevel`
             expect(builder.getContext().level).toBe(LogLevel.Warn)
         })
 
-        it ('with `OC.debug`', async () => {
+        it ('with `_oc_debug`', async () => {
             setReadyState('loading')
             const builder = getLoggerBuilder()
             builder.detectLogLevel()
@@ -54,32 +54,32 @@ describe('detect logging level', () => {
 
             // Mock OC and trigger document loaded
             // @ts-ignore
-            window.OC = { debug: true }
+            window._oc_debug = true
             setReadyState('complete')
             await new Promise(process.nextTick);
 
             // Level should now be set
             expect('level' in builder.getContext()).toBe(true)
 
-            // Should default to warn as NC24 has no `OC.config.loglevel`
+            // Should default to warn as NC24 has no `_oc_config.loglevel`
             expect(builder.getContext().level).toBe(LogLevel.Debug)
         })
     })
 
     /* Since NC25 configuring the loglevel is possible */
-    describe('with `OC.config.loglevel`', () => {
+    describe('with `_oc_config.loglevel`', () => {
         beforeAll(() => {
             // @ts-ignore
-            window.OC = {
-                config: {
-                    loglevel: LogLevel.Info,
-                },
-                debug: false,
+            window._oc_config = {
+                loglevel: LogLevel.Info,
             }
+            window._oc_debug = false
         })
         afterAll(() => {
             // @ts-expect-error
-            delete window.OC
+            delete window._oc_config
+            // @ts-expect-error
+            delete window._oc_debug
         })
 
         it ('already loaded', async () => {
@@ -88,7 +88,7 @@ describe('detect logging level', () => {
             builder.detectLogLevel()
 
             expect('level' in builder.getContext()).toBe(true)
-            expect(builder.getContext().level).toBe(window.OC.config.loglevel)
+            expect(builder.getContext().level).toBe(window._oc_config.loglevel)
         })
 
         it ('stil loading', async () => {
@@ -108,11 +108,11 @@ describe('detect logging level', () => {
             // Level should now be set to configured one, also in logger
             expect('level' in builder.getContext()).toBe(true)
             expect('level' in logger.context).toBe(true)
-            expect(builder.getContext().level).toBe(window.OC.config.loglevel)
-            expect(logger.context.level).toBe(window.OC.config.loglevel)
+            expect(builder.getContext().level).toBe(window._oc_config.loglevel)
+            expect(logger.context.level).toBe(window._oc_config.loglevel)
         })
 
-        it ('with `OC.debug` override', async () => {
+        it ('with `_oc_debug` override', async () => {
             setReadyState('loading');
             const builder = getLoggerBuilder()
             builder.detectLogLevel()
@@ -121,7 +121,7 @@ describe('detect logging level', () => {
             expect('level' in builder.getContext()).toBe(false)
 
             // Trigger document loaded
-            window.OC.debug = true
+            window._oc_debug = true
             setReadyState('complete')
             await new Promise(process.nextTick);
 
@@ -130,7 +130,7 @@ describe('detect logging level', () => {
             expect(builder.getContext().level).toBe(LogLevel.Debug)
         })
 
-        it ('with `OC.debug` override on HTML interactive phase', async () => {
+        it ('with `_oc_debug` override on HTML interactive phase', async () => {
             setReadyState('loading');
             const builder = getLoggerBuilder()
             builder.detectLogLevel()
@@ -139,7 +139,7 @@ describe('detect logging level', () => {
             expect('level' in builder.getContext()).toBe(false)
 
             // Trigger document loaded
-            window.OC.debug = true
+            window._oc_debug = true
             setReadyState('interactive')
             await new Promise(process.nextTick);
 


### PR DESCRIPTION
`OC.debug declaration`: https://github.com/nextcloud/server/blob/65b1c8b6e83b8a31a78b7ba18faeeb22c33258c2/core/src/OC/debug.js#L23-L26
`OC.config` declaration: https://github.com/nextcloud/server/blob/65b1c8b6e83b8a31a78b7ba18faeeb22c33258c2/core/src/OC/config.js#L23-L26