### PR TITLE
chore: Prepare 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.0.0 - 2024-04-22
+Note: This package is now ESM by default.
+
+### Changed
+* chore: Migrate to vite and `@nextcloud/vite-config` to also build an ESM entry point
+* fix: Update NPM version to LTS version 10
+
 ## 2.7.0 - 2023-09-20
 **Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-logger/compare/v2.6.1...v2.7.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/logger",
-  "version": "3.0.0-beta",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/logger",
-      "version": "3.0.0-beta",
+      "version": "3.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/logger",
-  "version": "3.0.0-beta",
+  "version": "3.0.0",
   "description": "Generic JavaScript logging interface for Nextcloud apps and libraries",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 3.0.0 - 2024-04-22
Note: This package is now ESM by default.

### Changed
* chore: Migrate to vite and `@nextcloud/vite-config` to also build an ESM entry point
* fix: Update NPM version to LTS version 10