### PR TITLE
fix: Drop CoreJS from package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     time: "03:00"
     timezone: Europe/Berlin
   open-pull-requests-limit: 10
+  versioning-strategy: increase
   commit-message:
     prefix: "chore"
     include: "scope"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,23 +9,22 @@
       "version": "3.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/auth": "^2.0.0",
-        "core-js": "^3.6.4"
+        "@nextcloud/auth": "^2.3.0"
       },
       "devDependencies": {
-        "@nextcloud/browserslist-config": "^3.0.0",
-        "@nextcloud/eslint-config": "^8.3.0-beta.2",
-        "@nextcloud/typings": "^1.6.0",
-        "@nextcloud/vite-config": "^1.0.0-beta.19",
-        "@types/jest": "^29.2.5",
-        "@types/node": "^20.6.3",
-        "eslint": "^8.44.0",
-        "jest": "^29.3.1",
-        "jest-environment-jsdom": "^29.3.1",
-        "ts-jest": "^29.0.3",
-        "typedoc": "^0.25.0",
-        "typescript": "^5.0.2",
-        "vite": "5.2.10"
+        "@nextcloud/browserslist-config": "^3.0.1",
+        "@nextcloud/eslint-config": "^8.3.0",
+        "@nextcloud/typings": "^1.8.0",
+        "@nextcloud/vite-config": "^1.2.3",
+        "@types/jest": "^29.5.12",
+        "@types/node": "^20.12.7",
+        "eslint": "^8.57.0",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "ts-jest": "^29.1.2",
+        "typedoc": "^0.25.13",
+        "typescript": "^5.4.5",
+        "vite": "^5.2.10"
       },
       "engines": {
         "node": "^20.0.0",
@@ -4103,16 +4102,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/core-js": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
-      "integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -39,19 +39,19 @@
     "core-js": "^3.6.4"
   },
   "devDependencies": {
-    "@nextcloud/browserslist-config": "^3.0.0",
-    "@nextcloud/eslint-config": "^8.3.0-beta.2",
-    "@nextcloud/typings": "^1.6.0",
-    "@nextcloud/vite-config": "^1.0.0-beta.19",
-    "@types/jest": "^29.2.5",
-    "@types/node": "^20.6.3",
-    "eslint": "^8.44.0",
-    "jest": "^29.3.1",
-    "jest-environment-jsdom": "^29.3.1",
-    "ts-jest": "^29.0.3",
-    "typedoc": "^0.25.0",
-    "typescript": "^5.0.2",
-    "vite": "5.2.10"
+    "@nextcloud/browserslist-config": "^3.0.1",
+    "@nextcloud/eslint-config": "^8.3.0",
+    "@nextcloud/typings": "^1.8.0",
+    "@nextcloud/vite-config": "^1.2.3",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.12.7",
+    "eslint": "^8.57.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "typedoc": "^0.25.13",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.10"
   },
   "browserslist": [
     "extends @nextcloud/browserslist-config"

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "url": "https://github.com/nextcloud/nextcloud-logger"
   },
   "dependencies": {
-    "@nextcloud/auth": "^2.0.0",
-    "core-js": "^3.6.4"
+    "@nextcloud/auth": "^2.3.0"
   },
   "devDependencies": {
     "@nextcloud/browserslist-config": "^3.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "target": "ESNext",
-        "module": "commonjs",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
         "declaration": true,
         "outDir": "./dist",
         "declarationDir": "./dist",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,6 @@ import { createLibConfig } from '@nextcloud/vite-config'
 export default createLibConfig({
 	index: 'lib/index.ts',
 }, {
-	coreJS: {
-		usage: true,
-	},
 	minify: false,
 	libraryFormats: ['es', 'cjs'],
 	thirdPartyLicense: false, // non included all external


### PR DESCRIPTION
This is already included in Nextcloud server for years.
This now only causes Cypress errors in other libraries.