### PR TITLE
chore: Prepare 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.0.1 - 2024-04-24
+### Fixed
+* fix: Drop CoreJS from package.json
+
+### Changed
+* chore(deps): Bump @nextcloud/auth from 2.2.1 to 2.3.0
+* feat: Migrate to vitest for testing
+
 ## 3.0.0 - 2024-04-22
 Note: This package is now ESM by default.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/logger",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/logger",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/logger",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Generic JavaScript logging interface for Nextcloud apps and libraries",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 3.0.1 - 2024-04-24
### Fixed
* fix: Drop CoreJS from package.json

### Changed
* chore(deps): Bump `@nextcloud/auth` from 2.2.1 to 2.3.0
* feat: Migrate to vitest for testing

