### PR TITLE
fix: Do not leak global declared types into distribution bundle

### DIFF
--- a/lib/LoggerBuilder.ts
+++ b/lib/LoggerBuilder.ts
@@ -1,15 +1,6 @@
 import { getCurrentUser } from '@nextcloud/auth'
 import { IContext, ILogger, ILoggerFactory, LogLevel } from './contracts'
 
-declare global {
-    interface Window {
-        _oc_config: {
-            loglevel: LogLevel,
-        },
-        _oc_debug: boolean,
-    }
-}
-
 /**
  * @notExported
  */

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Ferdinand Thiessen <opensource@fthiessen.de>
+ * SPDX-License-Identifier: GPL-3.0-or-later or LGPL-3.0-or-later
+ */
+
+import type { LogLevel } from './contracts'
+
+declare global {
+	interface Window {
+		_oc_config: {
+			loglevel: LogLevel,
+		},
+		_oc_debug: boolean,
+	}
+}
+
+export {}


### PR DESCRIPTION
We should not have private definitions leaked into our distribution files